### PR TITLE
/frontendに開発環境用のDockerfileを追加、README等を更新

### DIFF
--- a/frontend/.dockerignore
+++ b/frontend/.dockerignore
@@ -1,0 +1,3 @@
+*
+!package.json
+!bun.lockb

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,4 @@
-DATABASE_URL=for
+DATABASE_URL=mysql://root@mysql:3306/captitalens
 NEXT_PUBLIC_GA_ID=bar
 GOOGLE_ID=baz
 GOOGLE_SECRET=qux

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:18-buster-slim AS base
+
+RUN apt-get update -y && apt-get install -y openssl
+
+FROM base AS dev
+ENV NODE_ENV=development
+WORKDIR /app
+COPY package.json ./
+COPY bun.lockb ./
+RUN ["npm", "install", "-g", "bun"]
+RUN ["bun", "install"]

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,6 +1,24 @@
 # frontend
 
-フロントエンドには Next.js、Prisma、Tailwind CSS を採用しています。
+フロントエンドには Next.js、Prisma、Tailwind CSS、bun を採用しています。
+
+## 開発環境の構築
+
+### Docker のセットアップ
+
+（省略）
+
+### 環境変数の準備
+
+```sh
+cp .env.example .env
+```
+
+### 開発環境の起動
+
+```sh
+docker compose up
+```
 
 ## Storybook
 

--- a/frontend/docker-compose.yml
+++ b/frontend/docker-compose.yml
@@ -1,0 +1,35 @@
+services:
+  mysql:
+    image: mysql:8.1
+    volumes:
+      - mysql_data:/var/lib/mysql
+    environment:
+      - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+    command: --default-authentication-plugin=mysql_native_password
+    ports:
+      - 3306:3306
+    healthcheck:
+      test: ["CMD", "mysqladmin", "ping", "-h", "localhost"]
+      timeout: 1s
+      retries: 30
+  frontend:
+    depends_on:
+      mysql:
+        condition: service_healthy
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: dev
+    volumes:
+      - type: bind
+        source: ./
+        target: /app
+    platform: linux/amd64
+    command: sh -c "bun run prisma-init && bun run dev"
+    restart: always
+    ports:
+      - 3000:3000
+
+volumes:
+  mysql_data:
+    driver: local

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
   },
   "scripts": {
     "dev": "next dev",
+    "prisma-init": "prisma db push && prisma db seed",
     "build": "prisma generate && next build",
     "start": "next start",
     "lint": "next lint",


### PR DESCRIPTION
## このPull Requestの目的

- /frontendの開発環境の構築方法が、初見では、わかりにくい
- /frontendの開発環境を、より簡単に構築できるようにする
- これによって、より開発に貢献しやすくなる

## そのための方法

- /frontendに、Dockerfileとdocker-compose.ymlを追加する
- Dockerfileで基本的な開発環境の準備をする
- MySQLが必須なので、docker-compose.ymlには、開発用のMySQLを含める
- 起動時にPrismaの初期化を行う

## どうなるか

- /frontendで、 `docker compose up` コマンドを実行するだけで、 localhost:3000 で開発環境が立ち上がるはず


## Future Work

- ほとんど空っぽの状態で起動することになる
- Prismaのseedを充実させることで、開発環境における試行錯誤がやりやすくなるはず